### PR TITLE
Change phone normalization comparison to use array_diff_assoc rather tha...

### DIFF
--- a/CRM/Utils/Normalize.php
+++ b/CRM/Utils/Normalize.php
@@ -299,7 +299,7 @@ class CRM_Utils_Normalize {
             $normalization->normalize_phone($formattedPhoneValues);
 
             //do check for formatted difference, than only update.
-            $formattedDiff = array_diff($orgPhoneValues, $formattedPhoneValues);
+            $formattedDiff = array_diff_assoc($orgPhoneValues, $formattedPhoneValues);
             if (!empty($formattedDiff)) {
               $phoneUpdated = CRM_Core_BAO_Phone::add($formattedPhoneValues);
               if ($phoneUpdated->id) {


### PR DESCRIPTION
...n array_diff

Hi Nicolas!

When calling CRM_Utils_Normalize::processNormalization (to normalize over a range of contacts), there's a bug in the phone normalization.

Line 302 reads:
$formattedDiff = array_diff($orgPhoneValues, $formattedPhoneValues);

However, if those arrays have values like the ones I pasted below, $orgPhoneValues['phone'] matches on $formattedPhoneValues['phone_numeric'], and $formattedDiff is empty.  This PR changes it to an array_diff_assoc.

$orgPhoneValues
Array
(
    [id] => 54102
    [contact_id] => 13236
    [location_type_id] => 1
    [is_primary] => 1
    [is_billing] => 0
    [phone] => 3475555555
    [phone_numeric] => 3475555555
    [phone_type_id] => 1
)

$formattedPhoneValues
Array
(
    [id] => 54102
    [contact_id] => 13236
    [location_type_id] => 1
    [is_primary] => 1
    [is_billing] => 0
    [phone] => (347) 555-5555
    [phone_numeric] => 3475555555
    [phone_type_id] => 1
)
