### PR TITLE
Normalize names that are all uppercased

### DIFF
--- a/CRM/Utils/Normalize.php
+++ b/CRM/Utils/Normalize.php
@@ -134,6 +134,7 @@ class CRM_Utils_Normalize {
                }
             }
             if (!in_array($word, $handles)) {
+              $word = strtolower($word);
               $word = ucfirst($word);
             }
             array_push($newWords, $word);


### PR DESCRIPTION
The current normalization code seems geared toward names entered as all lowercase - but doesn't handle the situation of a name entered in all uppercase.  This PR addresses the all uppercase situation.