### PR TITLE
Fix a require_once error during the extension installation

### DIFF
--- a/normalize.php
+++ b/normalize.php
@@ -19,14 +19,15 @@
 */
 require_once 'normalize.civix.php';
 
+$extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+if (is_dir($extRoot . 'packages')) {
+  set_include_path($extRoot . 'packages' . PATH_SEPARATOR . get_include_path());
+}
+
 /**
  * Implementation of hook_civicrm_config
  */
 function normalize_civicrm_config(&$config) {
-  $extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
-  if (is_dir($extRoot . 'packages')) {
-    set_include_path($extRoot . 'packages' . PATH_SEPARATOR . get_include_path());
-  }
   _normalize_civix_civicrm_config($config);
 }
 


### PR DESCRIPTION
During the installation, there's a require_once error saying that the "libphonenumber/PhoneNumberUtil.php" could not be open.

This file is inside the packages folder, which is added to the include_path by the extension's `hook_civicrm_config`, which is not called before the file is required.

To fix it, I moved that code out of the hook_civicrm_config and it will now be called whenever the extensions is available, including during the installation.