### PR TITLE
don't blow away postal code on API update

### DIFF
--- a/CRM/Utils/Normalize.php
+++ b/CRM/Utils/Normalize.php
@@ -313,7 +313,9 @@ class CRM_Utils_Normalize {
     // Reformat postal code ONLY FOR CA
     if (CRM_Utils_Array::value('address_Zip', $this->_settings)) {
       // http://www.pidm.net/postal%20code.html: there are currently no examples of postal codes written with lower-case letters
-      $address['postal_code'] = strtoupper($address['postal_code']);
+      if ($address['postal_code']) {
+        $address['postal_code'] = strtoupper($address['postal_code']);
+      }
 
       if ($country == 'CA' && ($zip = CRM_Utils_Array::value('postal_code', $address))) {
         $zip = trim($zip);


### PR DESCRIPTION
When you do an address update via API, if you:
a) have postal code normalization enabled
b) don't explicitly set the postal code

Your postal code will be blown away on update.
To replicate:
```shell
cv api Address.create contact_id=5 location_type_id="Billing" city="Brooklyn" postal_code=11237 
cv api Address.create id=<previous address ID here>  city="Queens"
```

The offending line is the one I've wrapped in an `if` statement.  On an API update, the postal code isn't necessarily present, but the `strtoupper` line assumes it does, so if it doesn't exist, you end up with `$address['postal_code'] = ''`.  By wrapping that line in an `if`, the `$address['postal_code']` isn't created if it doesn't already exist.