### PR TITLE
Remove deprecated call to CRM_Core_Config::defaultContactCountry

### DIFF
--- a/CRM/Admin/Form/Setting/Normalize.php
+++ b/CRM/Admin/Form/Setting/Normalize.php
@@ -32,8 +32,7 @@ class CRM_Admin_Form_Setting_Normalize extends CRM_Admin_Form_Setting {
     if (!$this->_settings) $this->_settings = array();
 
     // Get the default country information for phone/zip formatting
-    $config = CRM_Core_Config::singleton();
-    $this->_country = $config->defaultContactCountry();
+    $this->_country = CRM_Core_BAO_Country::defaultContactCountry();
 
     $state = CRM_Utils_Request::retrieve('state', 'String', CRM_Core_DAO::$_nullObject, FALSE, 'tmp', 'GET');
     if ($state == 'done') {

--- a/CRM/Utils/Normalize.php
+++ b/CRM/Utils/Normalize.php
@@ -49,8 +49,7 @@ class CRM_Utils_Normalize {
   public function __construct() {
     $this->_settings = $this->getSettings();
     // Get the default country information for phone/zip formatting
-    $config = CRM_Core_Config::singleton();
-    $this->_country = $config->defaultContactCountry();
+    $this->_country = CRM_Core_BAO_Country::defaultContactCountry();
 
     $this->_nameFields = array('first_name', 'middle_name', 'last_name', 'organization_name', 'household_name', 'legal_name', 'nick_name');
     $this->_phoneFields = array('phone');


### PR DESCRIPTION
This replaces a two calls to `CRM_Core_Config::defaultContactCountry` (which was deprecated) with `CRM_Core_BAO_Country::defaultContactCountry();`.