### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/Contact/Normalize.php
+++ b/api/v3/Contact/Normalize.php
@@ -7,7 +7,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_contact_normalize($params) {
   $normalize = CRM_Utils_Normalize::singleton();


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.